### PR TITLE
Fixed tag URLs

### DIFF
--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -2,7 +2,7 @@
 <div class="tags">
     {{ range .Params.tags }}
       <div class="tag">
-        <a href="/tags/{{.}}">#{{.}}</a>
+        <a href="/tags/{{ . | urlize }}">#{{.}}</a>
       </div>
     {{ end }}
 </div>


### PR DESCRIPTION
This pull request fixes an issue with tags. As it stands, tags with whitespaces and other characters don't work because they are not urlized.