### PR TITLE
Fix gitlab.com social links

### DIFF
--- a/layouts/partials/social-links-footer.html
+++ b/layouts/partials/social-links-footer.html
@@ -9,7 +9,7 @@
   {{end}}
 
   {{with .Site.Params.gitlab}}
-  <a href="https://www.gitlab.com/{{.}}" target="_blank"><div class="social-link">GitLab</div></a>
+  <a href="https://gitlab.com/{{.}}" target="_blank"><div class="social-link">GitLab</div></a>
   {{end}}
 
   {{with .Site.Params.twitter}}

--- a/layouts/partials/social-links-footer.html
+++ b/layouts/partials/social-links-footer.html
@@ -9,7 +9,7 @@
   {{end}}
 
   {{with .Site.Params.gitlab}}
-  <a href="https://www.gitlab.com/in/{{.}}" target="_blank"><div class="social-link">GitLab</div></a>
+  <a href="https://www.gitlab.com/{{.}}" target="_blank"><div class="social-link">GitLab</div></a>
   {{end}}
 
   {{with .Site.Params.twitter}}

--- a/layouts/partials/social-links.html
+++ b/layouts/partials/social-links.html
@@ -10,7 +10,7 @@
   {{end}}
 
   {{with .Site.Params.gitlab}}
-  <a href="https://www.gitlab.com/{{.}}" target="_blank"><div class="social-link">GitLab</div></a>
+  <a href="https://gitlab.com/{{.}}" target="_blank"><div class="social-link">GitLab</div></a>
   {{end}}
 
   {{with .Site.Params.twitter}}

--- a/layouts/partials/social-links.html
+++ b/layouts/partials/social-links.html
@@ -10,7 +10,7 @@
   {{end}}
 
   {{with .Site.Params.gitlab}}
-  <a href="https://www.gitlab.com/in/{{.}}" target="_blank"><div class="social-link">GitLab</div></a>
+  <a href="https://www.gitlab.com/{{.}}" target="_blank"><div class="social-link">GitLab</div></a>
   {{end}}
 
   {{with .Site.Params.twitter}}


### PR DESCRIPTION
The GitLab social links in both the header and footer linked to `https://www.gitlab.com/in/{{.}}`,
which links to a 404. This PR fixes it. It also removes the `www` part to be consistent with the GitHub social links.