### PR TITLE
Added Support for Links in Copyright and robots.txt layout

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -5,6 +5,7 @@ languageCode = "en-US"
 canonifyurls = true
 paginate = 3
 theme = "hugo-dusk"
+enableRobotsTXT = true
 
 googleAnalytics = ""
 disqusShortname = ""

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
 
   {{ partial "social-links-footer.html" . }}
 
-  <div class="copyright"> {{ .Site.Copyright }} </div>
+  <div class="copyright"> {{ .Site.Copyright | safeHTML }} </div>
 
   <div class="poweredby">
     Powered by <a href="https://gohugo.io/">Hugo</a>.

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+
+Sitemap: {{ .Site.BaseURL }}/sitemap.xml


### PR DESCRIPTION
I added the safeHTML function to the copyright portion of the footer to allow the inclusion of links, e.g., Creative Commons Licenses.  I also added a layout for a basic "allow all" robots.txt file which includes a link to the sitemap.