### PR TITLE
set themesDir on exampleSite config file

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -5,6 +5,7 @@ languageCode = "en-US"
 canonifyurls = true
 paginate = 3
 theme = "hugo-dusk"
+themesDir = "../.."
 enableRobotsTXT = true
 
 googleAnalytics = ""


### PR DESCRIPTION
`themesDir <path>` on exampleSite config file is usually the de facto setting for anything in that directory