### PR TITLE
fix page lists, Hugo v0.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## [Unreleased]
 
 ### Changed
-  * minimal required Hugo version is v0.55
+  * minimal required Hugo version is v0.57.2
   * sort posts/pages on the error page by last modification date
 
 ### Fixed
+  * fix breaking change in mainSections introduced in Hugo v0.57.0
   * deprecation warnings during site build with v0.55 and newer
   * optimize image size when viewed on mobile devices
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 
 <main>
 
-{{ $paginator := .Paginate (where .Data.Pages "Type" "post") }}
+{{ $paginator := .Paginate (where site.RegularPages "Type" "in" site.Params.mainSections) }}
   {{ range $paginator.Pages }}
     {{ .Render "summary" }}
 {{ end }}

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "A minimalistic dark responsive theme."
 homepage = "https://github.com/gyorb/hugo-dusk"
 tags = ["blog", "responsive", "google analytics", "disqus", "syntax highlighting", "custom themes", "minimal", "minimalist", "clean", "dark"]
 features = ["blog"]
-min_version = 0.55
+min_version = "0.57.2"
 
 [author]
   name = "Gyorgy Orban"


### PR DESCRIPTION
Hugo v0.57 introduced a breaking change in mainSections.
Using .Site.RegularPages for the home page to resolve the issue.
mainSections is meant for the homepage.